### PR TITLE
Increase MAX_CHANNELS to 256

### DIFF
--- a/src/sound.h
+++ b/src/sound.h
@@ -126,7 +126,7 @@ void SNDDMA_Shutdown(void);
 // User-setable variables
 // ====================================================================
 
-#define MAX_CHANNELS         128
+#define MAX_CHANNELS         256
 #define MAX_DYNAMIC_CHANNELS 8
 #define MAX_RAW_SAMPLES      8192
 


### PR DESCRIPTION
This is necessary for the vanilla compatible Ritual map pack that has 150+ channels:

https://www.slipseer.com/index.php?resources/ritual.424/