### PR TITLE
add SDL window title vid_sdl.c

### DIFF
--- a/src/vid_sdl.c
+++ b/src/vid_sdl.c
@@ -207,7 +207,7 @@ static void VID_InitWindow(void) {
     int h = 0;
     Uint32 flags = SDL_WINDOW_RESIZABLE | SDL_WINDOW_ALLOW_HIGHDPI |
                    SDL_WINDOW_FULLSCREEN_DESKTOP;
-    window = SDL_CreateWindow(NULL, x, y, w, h, flags);
+    window = SDL_CreateWindow("Chocolate Quake", x, y, w, h, flags);
     if (window == NULL) {
         const char* error = SDL_GetError();
         Sys_Error("Error creating window for video startup: %s", error);


### PR DESCRIPTION
instead of NULL value, make the title the name of the running program

i noticed when using my "move window" script with `wmctrl -l` that there is not a window title set
it makes it difficult to find and track down the open window

adding this simple fix makes it possible to "call by name"
also should appear in OBS window management, if needed.
and also appear when ALT-TABBED with a window Title instead of being blank.


compiled tested and verified (linux):

`wmctrl -l`
```
0x0383f97f  0 Origin-EON-17S catbox@Origin-EON-17S /home/build/choc-quake/chocolate-quake/build/src
0x08600003  0 Origin-EON-17S vid_sdl.c
0x08800007  0 Origin-EON-17S Chocolate Quake
```

previously it would only show:
`0x08800007  0 Origin-EON-17S`
and could not be "selected" as easily.


Ideally, add a function such as "Chocolate Quake vX.XX" versioning if required, optional of course.
