### PR TITLE
Allow multiple client on same machine

### DIFF
--- a/src/net/net_dgrm.c
+++ b/src/net/net_dgrm.c
@@ -849,7 +849,7 @@ static qboolean NET_IsAlreadyConnected(
             continue;
         }
         const int ret = UDP_AddrCompare(addr, &s->addr);
-        if (ret < 0) {
+        if (ret != 0) {
             continue;
         }
         // Is this a duplicate connection request?


### PR DESCRIPTION
Fix bug #59. NET_IsAlreadyConnected now uses both the ip and the port to detect duplicate connections.