### PR TITLE
-game switch support absolute path

### DIFF
--- a/src/common/common.c
+++ b/src/common/common.c
@@ -1707,7 +1707,6 @@ void COM_InitFilesystem(void) {
         }
     }
 
-
     //
     // -path <dir or packfile> [<dir or packfile>] ...
     // Fully specifies the exact serach path, overriding the generated one


### PR DESCRIPTION
Closes #54

Though this won't address absolute path in windows.

Maybe check `com_argv[i + 1][1] == ':'` and if `true` assume its a windows absolute path?